### PR TITLE
Start Tween after configuring interpolation

### DIFF
--- a/scenes/CameraAnimation.gd
+++ b/scenes/CameraAnimation.gd
@@ -10,7 +10,6 @@ onready var animation = $AnimationPlayer
 
 func _ready():
 	seed(SEED)
-	tween.start()
 	env.dof_blur_near_enabled = true
 	env.dof_blur_far_enabled = true
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
@@ -50,6 +49,7 @@ func _on_Timer_timeout():
 		env, 'dof_blur_near_amount', blur_value, 0,
 		blur_time*0.5, Tween.TRANS_SINE, Tween.EASE_OUT_IN, blur_time*0.5
 	)
+	tween.start()
 
 
 func _input(event):

--- a/scenes/CameraShakingTimer.gd
+++ b/scenes/CameraShakingTimer.gd
@@ -14,7 +14,6 @@ var current_shake = 0
 
 func _ready():
 	explosion_timer.wait_time = final_shake_sec + fadeout_sec
-	tween.start()
 	global.connect('escape_door_available', self, '_on_escape_door_available')
 	global.connect('gameplay_started', self, '_on_gameplay_started')
 
@@ -56,6 +55,7 @@ func _process(delta):
 #			sound, 'volume_db', top_volume_db, -60, time*0.7, Tween.TRANS_SINE, Tween.EASE_IN_OUT,
 #			time*0.3
 #		)
+		tween.start()
 	else:
 		shaking_enabled = false
 		$Explosion.show()
@@ -75,6 +75,7 @@ func _process(delta):
 			sound, 'volume_db', sound.volume_db, -60, fadeout_sec,
 			Tween.TRANS_SINE, Tween.EASE_IN_OUT, final_shake_sec
 		)
+		tween.start()
 
 
 func _on_ExplosionTimer_timeout():

--- a/scenes/Door.gd
+++ b/scenes/Door.gd
@@ -19,7 +19,6 @@ func _ready():
 	
 	door_right_pos_closed = door_right.translation
 	door_right_pos_open = door_right_pos_closed + Vector3(0, 0, -1)
-	tween.start()
 	
 	var emission_color = Color(0.2, 0.8, 0.9) if active else Color(0.9, 0.2, 0.2)
 	
@@ -41,6 +40,7 @@ func _on_Area_body_entered(body):
 			door_right, "translation", door_right_pos_closed, door_right_pos_open,
 			opening_time, Tween.TRANS_SINE, Tween.EASE_IN
 		)
+		tween.start()
 		$OpenSound.play()
 
 
@@ -54,4 +54,5 @@ func _on_Area_body_exited(body):
 			door_right, "translation", door_right_pos_open, door_right_pos_closed,
 			opening_time, Tween.TRANS_SINE, Tween.EASE_IN
 		)
+		tween.start()
 		$CloseSound.play()

--- a/scenes/Locker.gd
+++ b/scenes/Locker.gd
@@ -22,7 +22,6 @@ var lock_enabled = true
 func _ready():
 #	for i in range(3):
 #		tumblers[i].rotation_degrees.x = current_combination[i] * 36
-	tween.start()
 
 
 func move_tumbler(number):
@@ -40,6 +39,7 @@ func move_tumbler(number):
 		tumblers[index], 'rotation_degrees', current_rotation, target_rotation,
 		0.2, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT
 	)
+	tween.start()
 	$Timer.start()
 	current_combination[index] = wrapi(current_combination[index], 0, 10)
 
@@ -101,6 +101,7 @@ func _on_InteractiveButton_activated():
 				tumblers[index], 'rotation_degrees', current_rotation, Vector3(0, 0, 0),
 				rotation_time, Tween.TRANS_LINEAR, Tween.EASE_IN_OUT
 			)
+		tween.start()
 		current_combination = [0, 0, 0]
 	$ButtonTimer.start()
 

--- a/scenes/Tablet.gd
+++ b/scenes/Tablet.gd
@@ -56,7 +56,6 @@ func _ready():
 	settings_background.rect_position.y = INITIAL_BAR_POS_Y
 	for button in [wifi_button, gps_button, pen_button]:
 		_toggle_button(button)
-	tween.start()
 
 func _wrap_planet_id(planet_index):
 	return wrapi(planet_index, 0, len(PLANET_NAMES))
@@ -95,6 +94,7 @@ func _end_swipe_action(swipe_delta):
 	tween.interpolate_method(
 		self, "_set_splits_delta", swipe_delta, target_delta, wait_time, Tween.TRANS_SINE, Tween.EASE_OUT
 	)
+	tween.start()
 	timer.wait_time = wait_time
 	timer.start()
 	initial_swipe_x_pos = null
@@ -141,6 +141,7 @@ func _end_bar_swipe(swipe_delta):
 		settings_background, "rect_position", settings_background.rect_position, Vector2(0, target_delta),
 		wait_time, Tween.TRANS_SINE, Tween.EASE_OUT
 	)
+	tween.start()
 	timer.wait_time = wait_time
 	timer.start()
 	bar_initial_swipe_y_pos = null


### PR DESCRIPTION
There was apparently a breaking change in Godot 3.1 (possibly
godotengine/godot#19781) which means that Tween will now stop processing
if it has nothing to do. So the previous code that pre-started Tween in
`_ready()` would not work in Godot 3.1.

The new code seems to work for both Godot 3.0.6 and 3.1.1.

---

Note: I haven't done extensive testing yet, simply checked that the doors work in both 3.0.6 and 3.1.1. I haven't tested other tweens that this PR attempts to fix similarly.